### PR TITLE
カスタムドメイン

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,9 +8,8 @@ export default function (eleventyConfig) {
   eleventyConfig.addGlobalData("year", () => new Date().getFullYear());
 
   return {
-    // GitHub Pages のプロジェクトページ配信（https://sYamaz.github.io/portfolio/）
-    // テンプレ内のリンク/アセットは必ず `| url` フィルタ経由にすること
-    pathPrefix: "/portfolio/",
+    // カスタムドメイン me.shunyamazaki.com のルートで配信するため pathPrefix は付けない
+    // （テンプレ内のリンク/アセットは引き続き `| url` フィルタ経由にすること）
     dir: {
       input: "src",
       includes: "_includes",


### PR DESCRIPTION
me.shunyamazaki.com のルートで配信するため、プロジェクトページ用の
pathPrefix "/portfolio/" を外す。リンク/アセットはルート起点になる。


Claude-Session: https://claude.ai/code/session_01YVjHQ93R8wxQhhkr4xELK5